### PR TITLE
Add map argument to PostCSSPlugin constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 var PostcssCompiler = require('broccoli-postcss');
 var checker = require('ember-cli-version-checker');
 
-function PostCSSPlugin (plugins, options) {
+// PostCSSPlugin constructor
+function PostCSSPlugin (options) {
   this.name = 'ember-cli-postcss';
-  options = options || {};
-  options.inputFile = options.inputFile || 'app.css';
-  options.outputFile = options.outputFile || 'app.css';
   this.options = options;
-  this.plugins = plugins;
+  this.plugins = options.plugins;
+  this.map = options.map;
 }
 
 PostCSSPlugin.prototype.toTree = function (tree, inputPath, outputPath) {
@@ -20,7 +19,7 @@ PostCSSPlugin.prototype.toTree = function (tree, inputPath, outputPath) {
   inputPath += '/' + this.options.inputFile;
   outputPath += '/' + this.options.outputFile;
 
-  return new PostcssCompiler(trees, inputPath, outputPath, this.plugins);
+  return new PostcssCompiler(trees, inputPath, outputPath, this.plugins, this.map);
 };
 
 module.exports = {
@@ -30,12 +29,17 @@ module.exports = {
   },
   included: function included (app) {
     this.app = app;
+    // Initialize options if none were passed
     var options = app.options.postcssOptions || {};
-    var plugins = this.plugins = options.plugins || [];
 
+    // Set defaults if none were passed
+    options.map = options.map || {};
+    options.plugins = options.plugins || [];
+    options.inputFile = options.inputFile || 'app.css';
     options.outputFile = options.outputFile || this.project.name() + '.css';
 
-    app.registry.add('css', new PostCSSPlugin(plugins, options));
+    // Add to registry and pass options
+    app.registry.add('css', new PostCSSPlugin(options));
 
     if (this.shouldSetupRegistryInIncluded()) {
       this.setupPreprocessorRegistry('parent', app.registry);


### PR DESCRIPTION
By accepting configuration for postcss' `map` options, sourcemaps can be configured from `Brocfile.js` with the `map` key. Instead of hardcoding the settings in broccoli-postcss (which currently does not generate a sourcemap). With this fix setting `map: true` (or leaving it empty, as it is the default), inline sourcemaps are correctly generated.

Simplified the default options as well. Needs https://github.com/jeffjewiss/broccoli-postcss/pull/3 to work and related to #2

A more elegant and permanent fix would be (in my opinion) to pass around a single `options` object, instead of separating all the options. But this at least fixes the basic functionality.