### PR TITLE
Use includePaths from assembled options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ PostcssPlugin.prototype.toTree = function (tree, inputPath, outputPath, inputOpt
   }
 
   if (options.includePaths) {
-    inputTrees = inputTrees.concat(this.options.includePaths)
+    inputTrees = inputTrees.concat(options.includePaths)
   }
 
   var plugins = options.plugins


### PR DESCRIPTION
```
this.options
```
was never set, so any truthy value for `includePaths` ends up throwing an error
```
Uncaught TypeError: Cannot read property 'includePaths' of undefined 
```