### PR TITLE
Move ember-cli-dependency-checker to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "broccoli-merge-trees": "2.0.0",
     "broccoli-postcss": "3.5.0",
     "broccoli-postcss-single": "1.4.0",
-    "ember-cli-dependency-checker": "2.0.1",
     "merge": "1.2.0"
   },
   "keywords": [
@@ -63,6 +62,7 @@
     "ember-cli": "^2.14.0",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-babel": "^6.6.0",
+    "ember-cli-dependency-checker": "2.0.1",
     "ember-cli-eslint": "^4.0.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0",


### PR DESCRIPTION
With this in `dependencies`, every app that uses ember-cli-postcss is also forced to run ember-cli-dependency-checker. That should be up to the app instead.

(I noticed this when trying to disable to dependency checker in an app as part of debugging a problem.)