### PR TITLE
Fix default trees and processing

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,11 +100,11 @@ module.exports = {
   postprocessTree (type, tree) {
     let { enabled, processTrees } = this._options.filter
 
-    if (!enabled) return tree
-
-    if (processTrees.includes(type)) {
-      return mergeTrees([tree, postcssFilter(tree, this._options.filter)], { overwrite: true })
+    if (enabled && processTrees.includes(type)) {
+      tree = mergeTrees([tree, postcssFilter(tree, this._options.filter)], { overwrite: true })
     }
+
+    return tree
   },
 
   setupPreprocessorRegistry (type, registry) {

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = {
         enabled: false,
         browsers,
         map: env !== 'development' ? false : {},
-        processTrees: ['all', 'styles'],
+        processTrees: ['all', 'css'],
         plugins: []
       }
     }, this._getAddonOptions(app).postcssOptions)


### PR DESCRIPTION
Through debugging this I found that `styles` doesn't come up as a tree type. The valid types are `['template', 'js', 'css', 'test', 'all']`.

`postprocessTrees` was not doing anything, so made the process function more like the previous version, and closer to the given example from the docs. This change makes the function process the tree correctly.