### PR TITLE
Remove reference to CssNext

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ If you are a developing an addon and would like to use `ember-cli-postcss` to pr
 ```javascript
 // index.js
 const CssImport = require('postcss-import')
-const CssNext = require('postcss-cssnext')
+const PresetEnv = require('postcss-preset-env');
 
 module.exports = {
   options: {
@@ -169,7 +169,7 @@ module.exports = {
         enabled: true,
         plugins: [
           { module: CssImport },
-          { module: CssNext }
+          { module: PresetEnv({ stage: 3 }) }
         ]
       }
     }


### PR DESCRIPTION
CssNext [has been deprecated](https://moox.io/blog/deprecating-cssnext/) ... and the owner seems to have gone off the deep end a bit 🤔I hope they're ok 🙈