### PR TITLE
[minor] Fix tempalte-> template typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ When using the compile method, the default list of file extensions for caching i
 
 If you are using something like **Tailwind** or a postcss plugin with a JS config file that you would like to trigger a rebuild, you will need to update the options to cache JS files: `cacheInclude: [/.*\.(css|scss|sass|less|js)$/],` or more specifically `cacheInclude: [/.*\.(css|scss)$/, /.tailwind\.js$/]`.
 
-If you are using something like **PurgeCSS** and would like postcss to rebuild when tempalte files are updated, you will need to update the options to cache HBS files: `cacheInclude: [/.*\.(css|scss|sass|less|hbs)$/],`. However, in most cases PurgeCSS should only be run for a production build and this shouldn't be necessary.
+If you are using something like **PurgeCSS** and would like postcss to rebuild when template files are updated, you will need to update the options to cache HBS files: `cacheInclude: [/.*\.(css|scss|sass|less|hbs)$/],`. However, in most cases PurgeCSS should only be run for a production build and this shouldn't be necessary.
 
 ## Example
 


### PR DESCRIPTION
Thanks for maintaining ember-cli-postcss! Small typo fix in the README