### PR TITLE
Use `requireModule('ember')` instead of `window.Ember`

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,17 @@ module.exports = {
   },
 
   treeForVendor () {
-    const content = `Ember.libraries.register('Ember Postcss', '${version}');`
+    const content = `
+{
+  let Ember;
+  try {
+    Ember = requireModule('ember')['default'];
+  } catch (error) {
+    Ember = window.Ember;
+  }
+  Ember.libraries.register('Ember Postcss', '${version}');
+}
+`
     const registerVersionTree = writeFile(
       'ember-cli-postcss/register-version.js',
       content


### PR DESCRIPTION
Because the latter is deprecated.

See https://github.com/emberjs/ember-inspector/pull/1535

I haven't tested that though.

Fixes #745, #760