### PR TITLE
float dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
-        "broccoli-merge-trees": "4.2.0",
-        "broccoli-postcss": "6.0.1",
-        "broccoli-postcss-single": "5.0.1",
-        "ember-cli-babel": "7.26.11",
-        "merge": "2.1.1"
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-postcss": "^6.0.1",
+        "broccoli-postcss-single": "^5.0.1",
+        "ember-cli-babel": "^7.26.11",
+        "merge": "^2.1.1"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     }
   },
   "dependencies": {
-    "broccoli-merge-trees": "4.2.0",
-    "broccoli-postcss": "6.0.1",
-    "broccoli-postcss-single": "5.0.1",
-    "ember-cli-babel": "7.26.11",
-    "merge": "2.1.1"
+    "broccoli-merge-trees": "^4.2.0",
+    "broccoli-postcss": "^6.0.1",
+    "broccoli-postcss-single": "^5.0.1",
+    "ember-cli-babel": "^7.26.11",
+    "merge": "^2.1.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.16.0",


### PR DESCRIPTION
This allows us consumers to keep them updated and deduplicated for a smaller node_modules bundle.